### PR TITLE
Order the shorter seq as the first argument

### DIFF
--- a/src/levenshtein.rs
+++ b/src/levenshtein.rs
@@ -5,7 +5,12 @@ use natural::distance::levenshtein_distance;
 pub(crate) struct Levenshtein {}
 impl Levenshtein {
     pub fn ratio(seq1: String, seq2: String) -> f64 {
-        let distance = levenshtein_distance(&seq1, &seq2);
+        let mut distance = 0;
+        if seq1.len() <= seq2.len() {           
+            let distance = levenshtein_distance(&seq1, &seq2);
+        } else {
+            let distance = levenshtein_distance(&seq2, &seq1);        
+        }
         let length = max(seq1.len(), seq2.len());
         1.0 - (distance as f64 / length as f64)
     }


### PR DESCRIPTION
Following the python example, the shorter string is seq1