### PR TITLE
Merge vocabulary and context building

### DIFF
--- a/yake_rust/src/lib.rs
+++ b/yake_rust/src/lib.rs
@@ -360,7 +360,6 @@ impl Yake {
             };
 
             {
-                // todo: revert back to the code from 5a6e4747, as tags change nothing
                 let tags: Vec<Tag> = occurrences.iter().map(|occ| occ.tag).collect();
                 // We consider the occurrence of acronyms through a heuristic, where all the letters of the word are capitals.
                 stats.tf_a = tags.iter().filter(|&tag| *tag == Tag::Acronym).count() as f64;

--- a/yake_rust/src/lib.rs
+++ b/yake_rust/src/lib.rs
@@ -298,7 +298,7 @@ impl Yake {
                 if window.len() == self.config.window_size {
                     window.pop_front();
                 }
-                window.push_back((term, tag.clone()));
+                window.push_back((term, tag));
             }
         }
 

--- a/yake_rust/src/lib.rs
+++ b/yake_rust/src/lib.rs
@@ -264,13 +264,8 @@ impl Yake {
         for (idx, sentence) in sentences.iter().enumerate() {
             let mut window: VecDeque<(&UTerm, Tag)> = VecDeque::with_capacity(self.config.window_size + 1);
 
-            for (w_idx, (((word, term), &is_punctuation), index)) in sentence
-                .words
-                .iter()
-                .zip(&sentence.uq_terms)
-                .zip(&sentence.is_punctuation)
-                .zip(&sentence.uq_terms)
-                .enumerate()
+            for (w_idx, ((word, term), &is_punctuation)) in
+                sentence.words.iter().zip(&sentence.uq_terms).zip(&sentence.is_punctuation).enumerate()
             {
                 if is_punctuation {
                     window.clear();
@@ -282,7 +277,7 @@ impl Yake {
 
                 let tag = self.get_tag(word, w_idx == 0);
                 let occurrence = Occurrence { idx, word, tag };
-                words.entry(index).or_default().push(occurrence);
+                words.entry(term).or_default().push(occurrence);
 
                 // Do not store in contexts in any way if the word (not the unique term) is tagged "d" or "u"
                 if tag != Tag::Digit && tag != Tag::Unparsable {

--- a/yake_rust/src/tag.rs
+++ b/yake_rust/src/tag.rs
@@ -1,8 +1,6 @@
 use std::collections::HashSet;
 
-use crate::Occurrence;
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Tag {
     /// "d"
     Digit,
@@ -26,9 +24,9 @@ impl Tag {
         word.chars().all(char::is_uppercase)
     }
 
-    pub fn is_uppercase(strict_capital: bool, occurrence: &Occurrence) -> bool {
-        let is_capital = if strict_capital { is_strict_capitalized } else { is_capitalized };
-        !occurrence.is_first_word_of_sentence() && is_capital(occurrence.word)
+    pub fn is_uppercase(strict_capital: bool, word: &str, is_first_word_of_sentence: bool) -> bool {
+        let is_capital: fn(&str) -> bool = if strict_capital { is_strict_capitalized } else { is_capitalized };
+        !is_first_word_of_sentence && is_capital(word)
     }
 
     pub fn is_unparsable(word: &str, punctuation: &HashSet<char>) -> bool {


### PR DESCRIPTION
Partially addresses #46 

Context and vocabulary building each had their own separate loop over all tokens, and tag functions were called multiple times for the same word. Occurrences stored shifts and offsets even though the only thing that was relevant was whether it was at the start of a sentence or not.

This merges context and vocabulary building into one function, one loop, that calculates the tag for each occurrence only once.

I suspect that `extract_features` and filtering could also be merged into the same loop.

I assume that reducing the number of loops and function calls is a performance improvement, but I will rely on @xamgore to verify this :)